### PR TITLE
Bump log4j-core from 2.11.1 to 2.13.2 in /org.dieschnittstelle.ess.jrs

### DIFF
--- a/org.dieschnittstelle.ess.jrs/pom.xml
+++ b/org.dieschnittstelle.ess.jrs/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.11.1</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.dieschnittstelle.ess</groupId>


### PR DESCRIPTION
Bumps log4j-core from 2.11.1 to 2.13.2.

Signed-off-by: dependabot[bot] <support@github.com>